### PR TITLE
Fix some typos on SuggestionV2's README

### DIFF
--- a/suggestion/v2/README.md
+++ b/suggestion/v2/README.md
@@ -19,15 +19,15 @@ Example - For a server with prefix - `?`, Trigger would be : `(?i)\A(\?\s?|<@!?2
 
 2. `$Logging_Channel` - 
 
-	The channel where messages regarding denied/approved/implemented and suggestions marked as dupe are sent. It us suggested to keep it separate from the $Suggestion_Channe to reduce clutter but depends on personal taste. 
+	The channel where messages regarding denied/approved/implemented and suggestions marked as dupe are sent. It is suggested to keep it separate from the $Suggestion_Channel to reduce clutter but depends on personal taste. 
 
 3. `$Implemented_Channel` -
 	
-	The channel where suggestions which have been marked as implemented are sent. This provides a good way to organise all implemnted suggestions into a separate channel.
+	The channel where suggestions which have been marked as implemented are sent. This provides a good way to organise all implemented suggestions into a separate channel.
 	
 4. `$Approved_Channel` -
 	
-	The channel where suggestions which have been marked as approved are sent. This provides a good way to organise all approved suggestions. This provides a good way to organise all implemnted suggestions into a separate channel. It is very much possible to set the same channel for tracking approved+implemented suggestions by using the same channel id in both variables.
+	The channel where suggestions which have been marked as approved are sent. This provides a good way to organise all approved suggestions. This provides a good way to organise all implemented suggestions into a separate channel. It is very much possible to set the same channel for tracking approved+implemented suggestions by using the same channel ID in both variables.
 
 *Note:* Among the **above** variables all channels can be separate or same. All combinations are possible. 
 
@@ -35,19 +35,19 @@ Example - For a server with prefix - `?`, Trigger would be : `(?i)\A(\?\s?|<@!?2
 
 5. `$Mod_Roles` -
 
-	List of all role ids of moderators who shpuld have access to all the suggestadmin commands. You do no need to specify roles who have `administrator` permissions in your server. They will have access by default.
+	List of all role ids of moderators who should have access to all the suggestadmin commands. You do no need to specify roles who have `administrator` permissions in your server. They will have access by default.
 
 6. `$Cooldown` -
 
-	Colldown in seconds between consucutive suggestions. This prevents suggestion misuse/spam. Can be set to 0 to disable. Mods/Admins can bypass the cooldown.
+	Cooldown in seconds between consecutive suggestions. This prevents suggestion misuse/spam. Can be set to 0 to disable. Mods/Admins can bypass the cooldown.
 
 7. `$Upvote` -
 
-	The emoji for upvote reaction. Supports both custom as well as inbuilt emojis. For inbuilt emojis, it is recommended to use corresponding unicode characters. Example : "👍".
+	The emoji for upvote reaction. Supports both custom as well as inbuilt emojis, for which it is recommended to use corresponding unicode characters. Example : "👍".
 	
 8. `$Downvote` -
 
-	The emoji for downvote reaction. Supports both custom as well as inbuilt emojis. For inbuilt emojis, it is recommended to use corresponding unicode characters. Example : "👎".
+	The emoji for downvote reaction. Supports both custom as well as inbuilt emojis, for which it is recommended to use corresponding unicode characters. Example : "👎".
 
 
 # Commands

--- a/suggestion/v2/README.md
+++ b/suggestion/v2/README.md
@@ -43,11 +43,11 @@ Example - For a server with prefix - `?`, Trigger would be : `(?i)\A(\?\s?|<@!?2
 
 7. `$Upvote` -
 
-	The emoji for upvote reaction. Supports both custom as well as inbuilt emojis, for which it is recommended to use corresponding unicode characters. Example : "👍".
+	The emoji for upvote reaction. Supports both custom as well as inbuilt emojis. For inbuilt emojis, it is recommended to use corresponding unicode characters. Example : "👍".
 	
 8. `$Downvote` -
 
-	The emoji for downvote reaction. Supports both custom as well as inbuilt emojis, for which it is recommended to use corresponding unicode characters. Example : "👎".
+	The emoji for downvote reaction. Supports both custom as well as inbuilt emojis. For inbuilt emojis, it is recommended to use corresponding unicode characters. Example : "👎".
 
 
 # Commands


### PR DESCRIPTION
Some notes:

- In `Configuration Variables -> 4.` I've seen this, but I'm not sure if that's OK:
> This provides a good way to organise all approved suggestions. This provides a good way to organise all implemnted suggestions into a separate channel.

- In `Configuration Variables -> 7. and 8.` I've edited this:
> Supports both custom as well as inbuilt emojis, for which it is recommended...

Is that better than previous redaction?